### PR TITLE
feat: implement ChatRoom component with Socket.IO integration

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import './App.css';
 import Login from './components/Login';
-// import ChatRoom from './components/ChatRoom'; // ← 後で作成するので今はコメントアウト
+import ChatRoom from './components/ChatRoom';
 
 function App() {
   const [nickname, setNickname] = useState(null);
@@ -9,7 +9,7 @@ function App() {
   return (
     <div className="App">
       {nickname
-        ? <div>ChatRoomへ進む予定（まだ未実装）</div>
+        ? <ChatRoom nickname={nickname} />
         : <Login onLogin={setNickname} />
       }
     </div>
@@ -17,4 +17,3 @@ function App() {
 }
 
 export default App;
-

--- a/client/src/components/ChatRoom.js
+++ b/client/src/components/ChatRoom.js
@@ -1,0 +1,66 @@
+// client/src/components/ChatRoom.js
+
+import React, { useEffect, useState } from 'react';
+import { io } from 'socket.io-client';
+
+const SOCKET_URL = process.env.REACT_APP_BACKEND_URL || 'http://localhost:4000';
+
+export default function ChatRoom({ nickname }) {
+  const [socket] = useState(() => io(SOCKET_URL));
+  const [room] = useState('general');                // 固定ルーム名
+  const [message, setMessage] = useState('');        // 入力中のテキスト
+  const [messages, setMessages] = useState([]);      // 受信メッセージの配列
+
+  useEffect(() => {
+    // ルーム参加
+    socket.emit('join_room', room);
+    // メッセージ受信時のハンドラ
+    socket.on('receive_message', data => {
+      setMessages(prev => [...prev, data]);
+    });
+    // コンポーネントアンマウント時に切断
+    return () => socket.disconnect();
+  }, [socket, room]);
+
+  // メッセージ送信
+  const sendMessage = () => {
+    if (!message.trim()) return;
+    socket.emit('send_message', {
+      room,
+      author: nickname,
+      message
+    });
+    setMessage('');
+  };
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h2>ようこそ、{nickname} さん (ルーム: {room})</h2>
+      <div style={{
+        border: '1px solid #ccc',
+        height: '300px',
+        overflowY: 'auto',
+        padding: '0.5rem',
+        marginBottom: '1rem'
+      }}>
+        {messages.map((m, i) => (
+          <div key={i}>
+            <strong>{m.author}</strong> <small>({new Date(m.timestamp).toLocaleTimeString()})</small>
+            <p>{m.message}</p>
+          </div>
+        ))}
+      </div>
+      <div>
+        <input
+          style={{ width: '70%', marginRight: '0.5rem' }}
+          type="text"
+          value={message}
+          onChange={e => setMessage(e.target.value)}
+          onKeyPress={e => e.key === 'Enter' && sendMessage()}
+          placeholder="メッセージを入力…"
+        />
+        <button onClick={sendMessage}>送信</button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要
ChatRoom コンポーネントを追加し、Socket.IO によるリアルタイム送受信を実装しました。

## 変更点
- src/components/ChatRoom.js の追加
- App.js を修正し、Login → ChatRoom への画面遷移を実装

## 動作確認
1. npm start で http://localhost:3000 を開く
2. 二つ以上のタブでニックネーム登録 → メッセージ送信 → リアルタイムに表示されることを確認
