### PR TITLE
メッセージ永続化機能の導入（MongoDB 接続＆ Message モデル追加）

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -1,0 +1,11 @@
+// server/db.js
+const mongoose = require('mongoose');
+
+mongoose.connect(process.env.MONGO_URI, {
+  useNewUrlParser: true,
+  useUnifiedTopology: true
+})
+  .then(() => console.log('✅ MongoDB connected'))
+  .catch(err => console.error('❌ MongoDB connection error:', err));
+
+module.exports = mongoose;

--- a/server/models/Message.js
+++ b/server/models/Message.js
@@ -1,0 +1,12 @@
+// server/models/Message.js
+const mongoose = require('mongoose');
+const { Schema } = mongoose;
+
+const messageSchema = new Schema({
+  room:      { type: String, required: true },
+  author:    { type: String, required: true },
+  message:   { type: String, required: true },
+  timestamp: { type: Date,   default: Date.now }
+});
+
+module.exports = mongoose.model('Message', messageSchema);


### PR DESCRIPTION
## 概要
チャットアプリのメッセージを MongoDB に保存・取得できるように、以下の永続化機能を追加しました。

## 変更内容
1. **MongoDB 接続モジュールの追加**  
   - `server/db.js` を新規作成  
   - `.env` に `MONGO_URI` を設定して、mongoose で接続

2. **Message モデルの追加**  
   - `server/models/Message.js` を新規作成  
   - `room`、`author`、`message`、`timestamp` を持つスキーマを定義

3. **メッセージ保存処理の追加**  
   - `server/server.js` の `send_message` ハンドラ内で、受信したメッセージを `new Message(...).save()` で DB に保存

4. **過去メッセージ取得 API の追加**  
   - `GET /messages/:room` エンドポイントを実装し、指定ルームの履歴をタイムスタンプ順に返却

## 動作確認手順
1. **MongoDB を起動**（ローカルに `mongod` が動作していることを確認）
2. **環境変数**  
   - `server/.env` に `MONGO_URI=mongodb://localhost:27017/realtime-chat-db` を設定
3. **サーバー起動**  
   ```bash
   cd server
   npm install    # mongoose を含む依存をインストール
   npm run dev
